### PR TITLE
Fix team name conventions, add data classification standards

### DIFF
--- a/policies/Acceptable_use_policy.md
+++ b/policies/Acceptable_use_policy.md
@@ -4,9 +4,12 @@
 
 The UC Berkeley School of Information GitHub org is intended to host repos that support our degree programs, and is not intended to host general purpose GitHub repos.  The following terms and conditions apply:
 
-1. All usage of this GitHub org falls under the School of Information's [Acceptable Use Policy](https://www.ischool.berkeley.edu/aup)(AUP).
-2. In addition to the School's general AUP, all usage of the School of Information GitHub org must comply with the specific policies in this repo.
-3. Use of this GitHub org to host repos is at the repo owner's own risk.  Given the number of people with access to this GitHub org, we strongly encourage repo owners to only host repos that are suitable for wide distribution.
+1. All repos are expected to conform to the following UC Berkeley [Data Classification Standard](https://security.berkeley.edu/data-classification-standard) protection levels.
+    1. Public repos may only contain protection level P1 data
+    2. Private repos may only contain protection level P1 and P2 data 
+2. All usage of this GitHub org falls under the School of Information's [Acceptable Use Policy](https://www.ischool.berkeley.edu/aup)(AUP).
+3. In addition to the School's general AUP, all usage of the School of Information GitHub org must comply with the specific policies in this repo.
+4. Use of this GitHub org to host repos is at the repo owner's own risk.  Given the number of people with access to this GitHub org, we strongly encourage repo owners to only host repos that are suitable for wide distribution.
 
 Please contact the School of Information IT team with any questions you may have about acceptable uses of the UC Berkeley School of Information GitHub org.
 

--- a/policies/Team_naming_conventions.md
+++ b/policies/Team_naming_conventions.md
@@ -29,8 +29,8 @@ The following rules should be applied from left to right when naming a team:
 
 The following are all valid examples of team names created by faculty to support instruction:
 
-* mids_w200_instructors
-* mids_w200_students_spring21
+* mids-w200-instructors
+* mids-w200-students-spring21
 
 ## Policy Enforcement
 


### PR DESCRIPTION
This PR includes the following changes:

* Use the same convention for both team and repo names (hyphens rather than underscores).
* Add UC Berkeley data classification standard requirements to acceptable use policy